### PR TITLE
remove: installation step from sync script

### DIFF
--- a/lib/zesty/sync.js
+++ b/lib/zesty/sync.js
@@ -65,47 +65,6 @@
          ),
      },
      {
-      title: 'Installing Template',
-      skip: (ctx) => {
-        // what logic will we use to decide if installer has already ran?
-        if (ctx.nextConfig.runinstaller !== true) {
-          return 'Installer already ran on this project.';
-        }
-      },
-      task: async (ctx) => {
-        try {
-          const { stdout } = await execa('zesty', ['auth:get-user-token']);
-           if (!stdout) {
-             throw new Error(
-               `Login using the command: ${chalk.bold('zesty auth:login')}`,
-             );
-           }
-          const instance = Object.values(zestyConfig)[0];
-          await fetch(
-            `https://installer-xytrmaqk4a-uc.a.run.app/install`,
-            {
-              method: 'POST',
-              headers: {
-                Authorization: `Bearer ${stdout}`,
-                'Content-Type': 'application/json',
-              },
-              body: JSON.stringify({
-                instance_zuid: instance.ZUID,
-                repository: templaterepo, // this needs to be dyanmic to the template install with sync 
-              }), 
-            },
-          )
-          .then((res) => res.json())
-          .catch((err) => {
-            throw new Error(`Failed to install instance`);
-          });
-          ctx.nextConfig.runinstaller = false;   
-        } catch (error) {
-          throw error;
-        }
-      }
-    },
-     {
        title: 'Fetching instance settings',
        skip: (ctx) => {
          if (ctx.nextConfig?.stage_password || ctx.nextConfig?.options?.skip_config_overwrite == true ) {


### PR DESCRIPTION
Installation of a template is a destructive action. As it will reset(read: delete existing database schema and content) an instance before installing the selected template schemas and content. 

While this is a necessary process to ensure the integrity of the selected template, it is not something which should happen during syncing. As such this PR removes the step from the sync script.

Instead installation is handled within the zesty/cli init command. Which only does an installation on a newly created instance. Which only occurs if the user has [no pre-existing instances](https://github.com/zesty-io/cli/blob/master/src/commands/init.ts#L156) and at the users direction. The [init command](https://github.com/zesty-io/nextjs-starter/blob/main/package.json#L13) occurs separately from the sync.

